### PR TITLE
Updates in list and use to prevent uninitialized errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag or version to build (e.g., v1.2.3). If not set, uses latest commit.'
+        required: false
+        default: ''
 
 jobs:
   release:
@@ -17,9 +22,10 @@ jobs:
       # id-token: write
     
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        ref: ${{ github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.sha }}
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,16 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # The base64 of the contents of your '.p12' key.
+        MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+        # The password to open the '.p12' key.
+        MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+        # The base64 of the contents of your '.p8' key.
+        MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        # The ID of the '.p8' key.
+        # You can find it in the filename, as well as the Apple Developer Portal
+        # website.
+        MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+        # The issuer UUID.
+        # You can find it in the Apple Developer Portal website.
+        MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.sha }}
+        ref: ${{ github.event.inputs.release_tag != '' && github.event.inputs.release_tag || github.ref_type == 'tag' && github.ref_name || github.sha }}
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Added by goreleaser init:
 dist/
 bin/
+.env

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,3 +98,64 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^typo:"
+
+notarize:
+  macos:
+    - # Whether this configuration is enabled or not.
+      #
+      # Default: false.
+      # Templates: allowed.
+      enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+
+      # Before notarizing, we need to sign the binary.
+      # This block defines the configuration for doing so.
+      sign:
+        # The .p12 certificate file path or its base64'd contents.
+        #
+        # Templates: allowed.
+        certificate: "{{.Env.MACOS_SIGN_P12}}"
+
+        # The password to be used to open the certificate.
+        #
+        # Templates: allowed.
+        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
+
+        # Allows to set the signature entitlements XML file.
+        #
+        # Templates: allowed.
+        # Since: v2.6.
+        entitlements: ./entitlements.xml
+
+      # Then, we notarize the binaries.
+      #
+      # You can leave this section empty if you only want
+      # to sign the binaries (Since: v2.1).
+      notarize:
+        # The issuer ID.
+        # Its the UUID you see when creating the App Store Connect key.
+        #
+        # Templates: allowed.
+        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
+
+        # Key ID.
+        # You can see it in the list of App Store Connect Keys.
+        # It will also be in the ApiKey filename.
+        #
+        # Templates: allowed.
+        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
+
+        # The .p8 key file path or its base64'd contents.
+        #
+        # Templates: allowed.
+        key: "{{.Env.MACOS_NOTARY_KEY}}"
+
+        # Whether to wait for the notarization to finish.
+        # Not recommended, as it could take a really long time.
+        wait: false
+
+        # Timeout for the notarization.
+        # Beware of the overall `--timeout` time.
+        # This only has any effect if `wait` is true.
+        #
+        # Default: 10m.
+        timeout: 20m

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,8 @@ release:
   prerelease: auto
 
   # If set to true, will not auto-publish the release.
-  draft: false
+  # We wait so that we don't make the release public until we have notarize email from Apple.
+  draft: true
 
   # What to do with the release notes in case there the release already exists.
   #

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,15 +20,13 @@ builds:
       - -X github.com/educates/educatesenv/pkg/version.Version={{ .Version }}
 
 archives:
-  - format: binary
+  - formats:
+      - binary
 
 checksum:
   name_template: 'checksums.txt'
   algorithm: sha256
   disable: false
-
-snapshot:
-  name_template: "{{ .Tag }}-next"
 
 # Documentation: https://goreleaser.com/customization/release/#github
 release:
@@ -37,8 +35,26 @@ release:
     owner: educates
     name: educatesenv
 
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default: false.
+  prerelease: auto
+
   # If set to true, will not auto-publish the release.
-  draft: true
+  draft: false
+
+  # What to do with the release notes in case there the release already exists.
+  #
+  # Valid options are:
+  # - `keep-existing`: keep the existing notes
+  # - `append`: append the current release notes to the existing notes
+  # - `prepend`: prepend the current release notes to the existing notes
+  # - `replace`: replace existing notes
+  #
+  # Default: `keep-existing`.
+  mode: replace
+
 
   # You can disable this pipe in order to not upload any artifacts.
   # Defaults to false.

--- a/entitlements.xml
+++ b/entitlements.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+    </dict>
+</plist>

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -2,12 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/educates/educatesenv/pkg/config"
 	"github.com/educates/educatesenv/pkg/platform"
@@ -24,35 +21,15 @@ var initCmd = &cobra.Command{
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		home, err := os.UserHomeDir()
+		_, defaultBin, configPath, configCreated, err := config.CreateConfigAndFolders()
 		if err != nil {
-			home = "."
-		}
-		configDir := filepath.Join(home, config.ConfigDirName)
-		defaultBin := filepath.Join(configDir, "bin")
-		configPath := filepath.Join(configDir, "config.yaml")
-
-		if err := os.MkdirAll(defaultBin, 0o755); err != nil {
-			return fmt.Errorf("failed to create bin directory: %w", err)
-		}
-		if err := os.MkdirAll(configDir, 0o755); err != nil {
-			return fmt.Errorf("failed to create config directory: %w", err)
+			return err
 		}
 
-		if _, err := os.Stat(configPath); err == nil {
-			fmt.Printf("Config file already exists at %s\n", configPath)
-		} else {
-			// Create new config with defaults
-			configFile := config.New()
-
-			yamlBytes, err := yaml.Marshal(&configFile)
-			if err != nil {
-				return fmt.Errorf("failed to marshal config to YAML: %w", err)
-			}
-			if err := os.WriteFile(configPath, yamlBytes, 0o644); err != nil {
-				return fmt.Errorf("failed to write config file: %w", err)
-			}
+		if configCreated {
 			fmt.Printf("Config file created at %s\n", configPath)
+		} else {
+			fmt.Printf("Config file already exists at %s\n", configPath)
 		}
 		fmt.Printf("Bin directory ensured at %s\n", defaultBin)
 

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/educates/educatesenv/pkg/config"
 	"github.com/spf13/cobra"
 )
 
@@ -17,8 +18,12 @@ var listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get all files in the bin directory
 		files, err := os.ReadDir(cfg.Local.Dir)
+		// If the bin directory doesn't exist call init
 		if err != nil {
-			return fmt.Errorf("failed to read bin directory: %w", err)
+			_, _, _, _, err := config.CreateConfigAndFolders()
+			if err != nil {
+				return fmt.Errorf("You should run `educatesenv init` first")
+			}
 		}
 
 		// Get the active version by reading the symlink

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -22,7 +22,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			_, _, _, _, err := config.CreateConfigAndFolders()
 			if err != nil {
-				return fmt.Errorf("You should run `educatesenv init` first")
+				return fmt.Errorf("you should run `educatesenv init` first")
 			}
 		}
 

--- a/pkg/cmd/use.go
+++ b/pkg/cmd/use.go
@@ -43,7 +43,7 @@ var useCmd = &cobra.Command{
 
 		// Handle regular version
 		if err := manager.UseVersion(version); err != nil {
-			return fmt.Errorf("Version %s is not installed. You should install it first with `educatesenv install %s`\n", version, version)
+			return fmt.Errorf("version %s is not installed. You should install it first with `educatesenv install %s`", version, version)
 		}
 
 		fmt.Printf("Now using educates version %s\n", version)

--- a/pkg/cmd/use.go
+++ b/pkg/cmd/use.go
@@ -43,7 +43,7 @@ var useCmd = &cobra.Command{
 
 		// Handle regular version
 		if err := manager.UseVersion(version); err != nil {
-			return fmt.Errorf("failed to switch to version %s: %w", version, err)
+			return fmt.Errorf("Version %s is not installed. You should install it first with `educatesenv install %s`\n", version, version)
 		}
 
 		fmt.Printf("Now using educates version %s\n", version)

--- a/pkg/version/manager.go
+++ b/pkg/version/manager.go
@@ -88,7 +88,12 @@ func (m *Manager) UseVersion(version string) error {
 
 	// Handle regular version
 	binaryPath := filepath.Join(m.config.Local.Dir, fmt.Sprintf("%s%s", platform.BinaryPrefix, version))
-	return m.createSymlink(binaryPath, symlinkPath)
+	err := m.createSymlink(binaryPath, symlinkPath)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
 }
 
 // GetPlatformBinaryName returns the platform-specific binary name


### PR DESCRIPTION
Fixes #2 

It also adds the ability to sign macOS binaries and the release.yaml workflow will publish the release as draft until we get Apple's notarization service email and we can publish with confidence